### PR TITLE
Change soname

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,8 @@ libgbm_la_CFLAGS =	\
 	-D_OS_UNIX=1	\
 	-DMODULEDIR='"$(exec_prefix)/lib/gbm"'
 
+libgbm_la_LDFLAGS = -version-info 1:0:0
+
 extdir = $(includedir)/gbm
 ext_HEADERS =		\
 	gbm.h		\


### PR DESCRIPTION
This produces libgbm.so.1.0.0 instead of libgbm.so.0.0.0.

Signed-off-by: Vincent Stehlé v-stehle@ti.com
