### PR TITLE
Fix udev linkage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AM_MAINTAINER_MODE
 AC_PROG_LIBTOOL
 
 # Obtain compiler/linker options for dependencies
-PKG_CHECK_MODULES(UDEV, udev)
+PKG_CHECK_MODULES(UDEV, libudev)
 PKG_CHECK_MODULES(DRM, libdrm)
 
 AC_CONFIG_FILES([Makefile gbm.pc])


### PR DESCRIPTION
It was asking for the wrong pkgconfig module - udev rather then libudev.
